### PR TITLE
accounts/views.py: Fix traceback

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -28,7 +28,7 @@ from models import UserSignup
 class ProfileFormView(FormView):
 	form_class = ProfileForm
 	template_name = 'accounts/profile_form.html'
-	success_url = reverse_lazy('accounts_profile_summary')
+	success_url = reverse_lazy('accounts_profile_home')
 
 	def get_initial(self):
 		return {


### PR DESCRIPTION
There appears to be no accounts_profile_summary defined in urls.py. This
fixes the following error.

NoReverseMatch: Reverse for 'accounts_profile_summary' with arguments '()' and keyword arguments '{}' not found.

Signed-off-by: Sol Jerome <sol.jerome@gmail.com>